### PR TITLE
Closes #38 - The e-mail archive is now optional.

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Settings.php
+++ b/CRM/Cdntaxreceipts/Form/Settings.php
@@ -209,7 +209,6 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
 
       $this->addRule('email_subject', 'Enter email subject', 'required');
       $this->addRule('email_from', 'Enter email from address', 'required');
-      $this->addRule('email_archive', 'Enter email archive address', 'required');
       $this->addRule('email_message', 'Enter email message', 'required');
     }
     else if ( $mode == 'defaults' ) {

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -96,6 +96,9 @@ function cdntaxreceipts_processTaxReceipt( $receipt, &$collectedPdf = NULL, $pre
     $mailparams['bcc'] = $email_archive;
   }
   else {
+    if ( empty($email_archive) ) {
+      $do_not_mail = 1;
+    }
     $mailparams['toEmail'] = $email_archive;
   }
 
@@ -103,7 +106,7 @@ function cdntaxreceipts_processTaxReceipt( $receipt, &$collectedPdf = NULL, $pre
     $ret = TRUE;
   }
   else {
-    $ret = CRM_Utils_Mail::send( $mailparams );
+    $ret = isset($do_not_mail) || CRM_Utils_Mail::send( $mailparams );
     if ( $ret == TRUE ) {
       // we have successfully processed.  Log the receipt.
       cdntaxreceipts_log($receipt);


### PR DESCRIPTION
You can leave the address empty. In that case CDNTaxReceipts does not try to send a mail when issueing a receipt.