### PR TITLE
Alternate serial receipt numbers

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Settings.php
+++ b/CRM/Cdntaxreceipts/Form/Settings.php
@@ -101,6 +101,7 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
   function processReceiptOptions($mode) {
     if ( $mode == 'build' ) {
       $this->add('text', 'receipt_prefix', ts('Receipt Prefix', array('domain' => 'org.civicrm.cdntaxreceipts')));
+      $this->add('checkbox', 'receipt_serial', ts('Serial Receipt Numbers', array('domain' => 'org.civicrm.cdntaxreceipts')));
       $this->add('text', 'receipt_authorized_signature_text', ts('Authorized Signature Text', array('domain' => 'org.civicrm.cdntaxreceipts')));
 
       $config = CRM_Core_Config::singleton( );
@@ -133,6 +134,7 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     else if ( $mode == 'defaults' ) {
       $defaults = array(
         'receipt_prefix' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_prefix'),
+        'receipt_serial' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_serial'),
         'receipt_authorized_signature_text' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_authorized_signature_text'),
       );
       return $defaults;
@@ -140,6 +142,7 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     else if ( $mode == 'post' ) {
       $values = $this->exportValues();
       CRM_Core_BAO_Setting::setItem($values['receipt_prefix'], self::SETTINGS, 'receipt_prefix');
+      CRM_Core_BAO_Setting::setItem('1', self::SETTINGS, 'receipt_serial');
       CRM_Core_BAO_Setting::setItem($values['receipt_authorized_signature_text'], self::SETTINGS, 'receipt_authorized_signature_text');
 
       $receipt_logo = $this->getSubmitValue('receipt_logo');

--- a/cdntaxreceipts.db.inc
+++ b/cdntaxreceipts.db.inc
@@ -283,4 +283,16 @@ function cdntaxreceipts_contributions_get_status($contributionIds = array()) {
   return $contributions;
 }
 
+/*
+ * cdntaxreceipts_log_next_id()
+ *
+ * Get the next id to be generated in the log table.
+ * Assumes that this table has an autoincrement id field.
+ * Does not deal with locking issue.
+ */
 
+function cdntaxreceipts_log_next_id() {
+  $sql = "SELECT id FROM cdntaxreceipts_log ORDER BY id DESC LIMIT 1";
+  $last_id = CRM_Core_DAO::singleValueQuery($sql);
+  return $last_id + 1;
+}

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -50,6 +50,18 @@ function cdntaxreceipts_processTaxReceipt( $receipt, &$collectedPdf = NULL, $pre
   // Get contact details
   list($displayname, $email) = CRM_Contact_BAO_Contact::getContactDetails($receipt['contact_id']);
 
+  $serial_receipt = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_serial');
+  if ($serial_receipt && empty($receipt['is_duplicate'])) {
+    // use my experimental alternative to generating serial receipt numbers, unless this is a re-issue
+    $lock = new CRM_Core_Lock('cdntaxreceipts.processTaxReceipt');
+    if (!$lock->acquire()) {
+      $userAlert = ts('Failed to acquire lock. No receipts were processed.');
+      CRM_Core_Session::setStatus($userAlert, ts('Warning'), 'alert');
+      return array(FALSE,'',NULL);
+    }
+    $next_id = cdntaxreceipts_log_next_id();
+    $receipt['receipt_no'] = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($next_id, 8, 0, STR_PAD_LEFT);
+  }
   // allow modules to alter any details
   // invoke hook_cdntaxreceipts_alter_receipt(&$receipt)
   //   modules should accept a reference to the $receipt array and alter it directly if they wish
@@ -108,6 +120,9 @@ function cdntaxreceipts_processTaxReceipt( $receipt, &$collectedPdf = NULL, $pre
       // we have successfully processed.  Log the receipt.
       cdntaxreceipts_log($receipt);
     }
+  }
+  if (!empty($lock)) {
+    $lock->release();
   }
 
   if ( $receipt['issue_method'] == 'email' ) {
@@ -572,13 +587,15 @@ function cdntaxreceipts_issueTaxReceipt( $contribution, &$collectedPdf = NULL, $
       return cdntaxreceipts_issueAggregateTaxReceipt($contactId, $year, $receipt['contributions'],
         $method, $collectedPdf, $previewMode);
     }
+    // be sure I'm not changing the receipt number
+    $receipt_no = $receipt['receipt_no'];
+  }
+  else { // generate a receipt number
+    $receipt_no = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($contribution->id, 8, 0, STR_PAD_LEFT);
   }
 
   // determine the send method
   list( $method, $email ) = cdntaxreceipts_sendMethodForContact($contribution->contact_id);
-
-  // generate a receipt number
-  $receipt_no = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($contribution->id, 8, 0, STR_PAD_LEFT);
 
   // process In-Kind variables if this is a receipt for an in-kind contribution
 

--- a/templates/CRM/Cdntaxreceipts/Form/Settings.tpl
+++ b/templates/CRM/Cdntaxreceipts/Form/Settings.tpl
@@ -57,6 +57,11 @@
           <p class="description">{ts domain='org.civicrm.cdntaxreceipts'}Receipt numbers are formed by appending the CiviCRM Contribution ID to this prefix. Receipt numbers must be unique within your organization. If you also issue tax receipts using another system, you can use the prefix to ensure uniqueness (e.g. enter 'WEB-' here so all receipts issued through CiviCRM are WEB-00000001, WEB-00000002, etc.){/ts}</p></td>
       </tr>
       <tr>
+        <td class="label">{$form.receipt_serial.label}</td>
+        <td class="content">{$form.receipt_serial.html}
+          <p class="description">{ts domain='org.civicrm.cdntaxreceipts'}This is an experimental option to generate receipt numbers serially, without the gaps of the default method described above. Not recommended unless your auditor insists.{/ts}</p></td>
+      </tr>
+      <tr>
         <td class="label">{$form.receipt_authorized_signature_text.label}</td>
         <td class="content">{$form.receipt_authorized_signature_text.html}
           <p class="description">{ts domain='org.civicrm.cdntaxreceipts'}Name and position of the authorizing official to be displayed under the signature line. Defaults to "Authorized Signature" if no name is specified.{/ts}</p></td>


### PR DESCRIPTION
As per issue #45. Pretty straightforward, won't affect existing standard numbering. One small improvement to the existing code base (i.e. no need, and potentially risky, to recalculate the receipt number of a re-issued receipt). I marked the option as experimental and not recommended.
