### PR TITLE
avoid generating tax receipts for negative contributions, issue #52

### DIFF
--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -759,10 +759,12 @@ function cdntaxreceipts_eligibleAmount( $contributionId ) {
     }
   }
 
-  // account for manually-entered non_deductible_amount
-  $deductibleAmount = $deductibleAmount - $contribution->non_deductible_amount;
-  if ( $deductibleAmount < 0 ) {
-    $deductibleAmount = 0;
+  // account for manually-entered (positive) non_deductible_amount
+  if ($contribution->non_deductible_amount > 0) {
+    $deductibleAmount = $deductibleAmount - $contribution->non_deductible_amount;
+    if ( $deductibleAmount < 0 ) {
+      $deductibleAmount = 0;
+    }
   }
  
   // 2. allow modules to alter the amount. lowest amount wins.


### PR DESCRIPTION
It's just a little extra check when accounting for manually-entered non_deductible_amount