### PR TITLE
Receipts sent to archive twice when sending core workflow msg

### DIFF
--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -281,6 +281,18 @@ function cdntaxreceipts_civicrm_validate( $formName, &$fields, &$files, &$form )
 }
 
 function cdntaxreceipts_civicrm_alterMailParams(&$params, $context) {
+  /*
+    When CiviCRM core sends receipt email using CRM_Core_BAO_MessageTemplate, this hook was invoked twice:
+    - once in CRM_Core_BAO_MessageTemplate::sendTemplate(), context "messageTemplate"
+    - once in CRM_Utils_Mail::send(), which is called by CRM_Core_BAO_MessageTemplate::sendTemplate(), context "singleEmail"
+
+    Hence, cdntaxreceipts_issueTaxReceipt() is called twice, sending 2 receipts to archive email.
+
+    To avoid this, only execute this hook when context is "messageTemplate"
+  */
+  if( $context != 'messageTemplate'){
+    return;
+  }
 
   $msg_template_types = array('contribution_online_receipt', 'contribution_offline_receipt');
 


### PR DESCRIPTION
When CiviCRM core sends receipt email using CRM_Core_BAO_MessageTemplate, this hook was invoked twice:

- once in CRM_Core_BAO_MessageTemplate::sendTemplate(), context "messageTemplate"
- once in CRM_Utils_Mail::send(), which is called by CRM_Core_BAO_MessageTemplate::sendTemplate(), context "singleEmail"

Hence, cdntaxreceipts_issueTaxReceipt() is called twice, sending 2 receipts to archive email.

To avoid this, only execute this hook when context is "messageTemplate".