### PR TITLE
Optional archive email

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Settings.php
+++ b/CRM/Cdntaxreceipts/Form/Settings.php
@@ -212,7 +212,6 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
       $this->add('text', 'email_archive', ts('Archive Email', array('domain' => 'org.civicrm.cdntaxreceipts')));
 
       $this->addRule('email_from', 'Enter email from address', 'required');
-      $this->addRule('email_archive', 'Enter email archive address', 'required');
     }
     else if ( $mode == 'defaults' ) {
       $defaults = array(

--- a/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
+++ b/CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php
@@ -271,7 +271,13 @@ class CRM_Cdntaxreceipts_Form_ViewTaxReceipt extends CRM_Core_Form {
       CRM_Utils_System::civiExit();
     }
     else {
-      $statusMsg = ts('File has expired. Please retrieve receipt from the email archive.', array('domain' => 'org.civicrm.cdntaxreceipts'));
+      $email_archive = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'email_archive');
+      if( !empty($email_archive) ){
+        $statusMsg = ts('File has expired. Please retrieve receipt from the email archive.', array('domain' => 'org.civicrm.cdntaxreceipts'));
+      }
+      else{
+        $statusMsg = ts('File has expired. Please reissue the tax reciept.', array('domain' => 'org.civicrm.cdntaxreceipts'));
+      }
       CRM_Core_Session::setStatus( $statusMsg, '', 'error' );
     }
   }

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -39,7 +39,7 @@ require_once('FPDI/fpdi.php');
  * processTaxReceipt()
  * Accepts an associative array containing receipt variables, and:
  * - generates a PDF file using the provided variables
- * - sends a copy of the receipt to the email archive
+ * - sends a copy of the receipt to the email archive if present
  * - emails the receipt to the donor if issue_method='email'
  * - logs the receipt to the audit log
  *
@@ -60,7 +60,7 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
   // generate the PDF file
   list($pdf_file, $user_friendly) = cdntaxreceipts_generateFormattedReceipt($receipt, $collectedPdf, $mode);
 
-  // generate an email to the tax archive and possibly to the donor
+  // generate an email to the tax archive if present and possibly to the donor
   if ( $mode == CDNTAXRECEIPTS_MODE_PREVIEW ) {
     $sent = TRUE;
   }
@@ -112,12 +112,17 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
       $sendTemplateParams['valueName'] = 'cdntaxreceipts_receipt_aggregate';
     }
 
-    // send a copy (without open tracking) to the tax archive
-    $sendTemplateParams['toEmail'] = $email_archive;
-    list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+    // Flag indicating whether tax receipt email was sent successfully
+    $sent = false;
+
+    // send a copy (without open tracking) to the tax archive if present
+    if( !empty($email_archive) ){
+      $sendTemplateParams['toEmail'] = $email_archive;
+      list($sent, $subject, $message, $html) = CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
+    }
 
     // send a copy (with open tracking) to the donor (sometimes)
-    if ($sent && $receipt['issue_method'] == 'email' && $mode != CDNTAXRECEIPTS_MODE_WORKFLOW) {
+    if ( (empty($email_archive) || $sent) && $receipt['issue_method'] == 'email' && $mode != CDNTAXRECEIPTS_MODE_WORKFLOW) {
       $sendTemplateParams['toEmail'] = $contact['email'];
       $sendTemplateParams['tplParams']['openTracking'] = "<img src=\"" . CRM_Utils_System::baseURL() .
         "civicrm/cdntaxreceipts/open?r={$receipt['email_tracking_id']}\" width='1' height='1' alt='' border='0'>";
@@ -126,8 +131,10 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
       // TODO: log an activity
     }
 
-    // log the receipt
-    if (!$receipt['is_duplicate'] && $sent) {
+    // log the receipt when:
+    // - tax receipt is emailed to either archive or the donor; OR
+    // - this function is called in cdntaxreceipts_civicrm_alterMailParams() to generate PDF tax receipt
+    if (!$receipt['is_duplicate'] && ($sent || $mode == CDNTAXRECEIPTS_MODE_WORKFLOW) ) {
       cdntaxreceipts_log($receipt);
     }
   }

--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -321,17 +321,15 @@ function cdntaxreceipts_civicrm_alterMailParams(&$params, $context) {
       CDNTAXRECEIPTS_MODE_WORKFLOW
     );
 
-    if ($ret) {
-      $last_in_path = strrpos($pdf_file, '/');
-      $clean_name = substr($pdf_file, $last_in_path);
-      $attachment = array(
-        'fullPath' => $pdf_file,
-        'mime_type' => 'application/pdf',
-        'cleanName' => $clean_name,
-      );
-      $params['attachments'] = array($attachment);
-    }
-
+    // No need to check if $ret is true (i.e. email sent), b/c it's not emailed out when using CDNTAXRECEIPTS_MODE_WORKFLOW and archive email is optional
+    $last_in_path = strrpos($pdf_file, '/');
+    $clean_name = substr($pdf_file, $last_in_path);
+    $attachment = array(
+      'fullPath' => $pdf_file,
+      'mime_type' => 'application/pdf',
+      'cleanName' => $clean_name,
+    );
+    $params['attachments'] = array($attachment);
   }
 
 }

--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -281,19 +281,7 @@ function cdntaxreceipts_civicrm_validate( $formName, &$fields, &$files, &$form )
 }
 
 function cdntaxreceipts_civicrm_alterMailParams(&$params, $context) {
-  /*
-    When CiviCRM core sends receipt email using CRM_Core_BAO_MessageTemplate, this hook was invoked twice:
-
-    - once in CRM_Core_BAO_MessageTemplate::sendTemplate(), context "messageTemplate"
-    - once in CRM_Utils_Mail::send(), which is called by CRM_Core_BAO_MessageTemplate::sendTemplate(), context "singleEmail"
-
-    Hence, cdntaxreceipts_issueTaxReceipt() is called twice, sending 2 receipts to archive email.
-    To avoid this, only execute this hook when context is "messageTemplate".
-  */
-  if( $context != 'messageTemplate'){
-    return;
-  }
-
+  
   $msg_template_types = array('contribution_online_receipt', 'contribution_offline_receipt');
 
   if (isset($params['groupName'])

--- a/templates/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.tpl
+++ b/templates/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.tpl
@@ -39,7 +39,7 @@
   <p>{ts domain='org.civicrm.cdntaxreceipts'}Clicking 'Issue Tax Receipts' will issue aggregate tax receipts grouped into the selected year(s). These tax receipts are a sum
     total of all selected eligible contributions, received from the donor during the selected year, that have not already been receipted individually.{/ts}</p>
   <p>{ts domain='org.civicrm.cdntaxreceipts'}<strong>This action cannot be undone.</strong> Tax receipts will be logged for auditing purposes,
-    and a copy of each receipt will be submitted to the tax receipt archive.{/ts}
+    and a copy of each receipt will be submitted to the tax receipt archive if an archive email address was provided in the extension setting.{/ts}
   <ul>
     <li>{ts domain='org.civicrm.cdntaxreceipts'}Email receipts will be emailed directly to the contributor.{/ts}</li>
     <li>{ts domain='org.civicrm.cdntaxreceipts'}Print receipts will be compiled into a file for download.  Please print and mail any receipts in this file.{/ts}</li>

--- a/templates/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.tpl
+++ b/templates/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.tpl
@@ -27,7 +27,7 @@
   were recorded after the annual receipt was issued, those contributions must be receipted one at a time. Use the Find
   Contributions action to issue those receipts.{/ts}</p>
   <p>{ts domain='org.civicrm.cdntaxreceipts'}<strong>This action cannot be undone.</strong> Tax receipts will be logged for auditing purposes,
-    and a copy of each receipt will be submitted to the tax receipt archive.{/ts}</p>
+    and a copy of each receipt will be submitted to the tax receipt archive if an archive email address was provided in the extension setting.{/ts}</p>
   <p>
   <ul>
   <li>{ts domain='org.civicrm.cdntaxreceipts'}Email receipts will be emailed directly to the contributor.{/ts}</li>

--- a/templates/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.tpl
+++ b/templates/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.tpl
@@ -28,7 +28,7 @@
      {$form.receipt_option.include_duplicates.html}</p>
   <p>{ts domain='org.civicrm.cdntaxreceipts'}Clicking 'Issue Tax Receipts' will issue the selected tax receipts.
     <strong>This action cannot be undone.</strong> Tax receipts will be logged for auditing purposes,
-    and a copy of each receipt will be submitted to the tax receipt archive.{/ts}</p>
+    and a copy of each receipt will be submitted to the tax receipt archive if an archive email address was provided in the extension setting.{/ts}</p>
   <ul>
   <li>{ts domain='org.civicrm.cdntaxreceipts'}Email receipts will be emailed directly to the contributor.{/ts}</li>
   <li>{ts domain='org.civicrm.cdntaxreceipts'}Print receipts will be compiled into a file for download.  Please print and mail any receipts in this file.{/ts}</li>


### PR DESCRIPTION
This branch makes archive email optional, as my organization do not want to archive the tax receipt email if it can be regenerated.

Change log:

CRM/Cdntaxreceipts/Form/Settings.php: remove rule for archive email to
make it optional

CRM/Cdntaxreceipts/Form/ViewTaxReceipt.php: if tax receipt PDF file is
expired (not found), and no archive email specified, instruct user to
reissue tax receipt.

cdntaxreceipts.functions.inc:
- Update comments in multiple places showing archive email is optional
- Do not send email to archive email if not specified
- Change logic for "if" statement when sending receipt email to donor to
  account for optional archive email
- Change logic for "if" statement when logging tax receipt

cdntaxreceipts.php: do not check email status when attaching tax receipt
to core workflow msg. Since archive email is optional, calling
"cdntaxreceipts_issueTaxReceipt()" function with
CDNTAXRECEIPTS_MODE_WORKFLOW doesn't always send email.

templates/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.tpl: update
text to show a copy of the tax receipt will send to the archive email if
specified.

templates/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.tpl: update
text to show a copy of the tax receipt will send to the archive email if
specified.

templates/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.tpl: update
text to show a copy of the tax receipt will send to the archive email if
specified.