### PR TITLE
Remove Contribution Custom fields from the Reports.

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Report/ReceiptsIssued.php
+++ b/CRM/Cdntaxreceipts/Form/Report/ReceiptsIssued.php
@@ -9,7 +9,7 @@ class CRM_Cdntaxreceipts_Form_Report_ReceiptsIssued extends CRM_Report_Form {
 
   function __construct() {
 
-    $this->_customGroupExtends = array('Contact', 'Individual', 'Organization', 'Contribution');
+    $this->_customGroupExtends = array('Contact', 'Individual', 'Organization');
     $this->_autoIncludeIndexedFieldsAsOrderBys = TRUE;
 
     $this->_columns = array(

--- a/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
+++ b/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
@@ -12,7 +12,7 @@ class CRM_Cdntaxreceipts_Form_Report_ReceiptsNotIssued extends CRM_Report_Form {
 
   function __construct() {
 
-    $this->_customGroupExtends = array('Contact', 'Individual', 'Organization', 'Contribution');
+    $this->_customGroupExtends = array('Contact', 'Individual', 'Organization');
     $this->_autoIncludeIndexedFieldsAsOrderBys = TRUE;
 
     $this->_columns = array(
@@ -223,7 +223,7 @@ CREATE TEMPORARY TABLE cdntaxreceipts_temp_civireport_eligible (
       $this->_where .= " AND {$this->_aliases['civicrm_contribution']}.receive_date >= {$month} ";
       CRM_Core_Session::setStatus(ts('For performance reasons, date range is limited to the current month. If you want to a different date range, please use the date filter.'), '', 'info');
     }
-    
+
     $sql = "SELECT {$this->_aliases['civicrm_contribution']}.id $this->_from $this->_where";
     $dao = CRM_Core_DAO::executeQuery($sql);
 


### PR DESCRIPTION
When selecting Contribution custom fields in the Tax Receipts Issued report - we get DB Errors - fatal errors. Seeing this in two projects. Since there can be multiple contributions on one TaxReceipt - I think it makes sense that we constrain the custom fields that can be inject to of entity 'Individual', 'Contact' and 'Organization' only. 
