### PR TITLE
Ensure that the session (UI) locale stays the same even if receipt locale is different

### DIFF
--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -54,6 +54,7 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
   list($displayname, $email) = CRM_Contact_BAO_Contact::getContactDetails($receipt['contact_id']);
 
   // add support for preferred language
+  $old_locale = CRM_Core_I18n::singleton()->getLocale();
   $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $receipt['contact_id'], 'preferred_language');
   _cdntaxreceipts_setReceiptanguage($preferred_language);
 
@@ -138,6 +139,9 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
       }
     }
   }
+
+  // Switch the locale back to the original locale
+  CRM_Core_I18n::singleton()->setLocale($old_locale);
 
   // log the receipt
   if (!$receipt['is_duplicate'] && $sent && $mode != CDNTAXRECEIPTS_MODE_PREVIEW) {


### PR DESCRIPTION
This partially fixes an odd bug where a person might use a public contribution page in
French. CiviCRM will create a new contact record and might set its preferred language
to English. The receipt gets sent in English, and then the user is sent to a confirmation
page in English (hence switching the UI locale).

This is only a partial fix, because if the user was on a French contribution page,
we would expect the tax receipt to be also in French, no matter which language is on
their contact record.

Possibly related: https://civicrm.stackexchange.com/questions/27074/contribution-page-validation-errors-display-and-confirmation-screen-switch-to-de