### PR TITLE
Bug fix in report, to include contributions with mixed financial types

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
+++ b/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
@@ -174,7 +174,6 @@ class CRM_Cdntaxreceipts_Form_Report_ReceiptsNotIssued extends CRM_Report_Form {
     else {
       $this->_where .= "
       AND {$this->_aliases['civicrm_contribution']}.contribution_status_id = 1
-      AND {$this->_aliases['civicrm_financial_type']}.is_deductible = 1
       AND ({$this->_aliases['civicrm_contribution']}.total_amount - COALESCE({$this->_aliases['civicrm_contribution']}.non_deductible_amount,0)) > 0
       ";
     }


### PR DESCRIPTION
I'm not sure if this applies to civi across the board or if this site has a strange usage. But in this site's case, they have online event payments using a price set that includes both event fees (non-tax-deduct) and donations (tax-deduct). The contribution objects in the db are created with the financial type in that table being event fee, which caused this report to skip over them (fixed now with this commit). The line item objects in the db have the correct financial types and otherwise civi and receipting appears to be correct.

This fix is rather important in this case, as without it the organization would likely miss receipting some donations.