### PR TITLE
Switch to new method of adding submitOnce behavior

### DIFF
--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -155,7 +155,7 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
         'type' => 'next',
         'name' => 'Issue Tax Receipts',
         'isDefault' => TRUE,
-        'js' => array('onclick' => "return submitOnce(this,'{$this->_name}','" . ts('Processing', array('domain' => 'org.civicrm.cdntaxreceipts')) . "');"),
+        'submitOnce' => TRUE,
       ),
     );
     $this->addButtons($buttons);

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -99,7 +99,7 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
         'type' => 'next',
         'name' => 'Issue Tax Receipts',
         'isDefault' => TRUE,
-        'js' => array('onclick' => "return submitOnce(this,'{$this->_name}','" . ts('Processing', array('domain' => 'org.civicrm.cdntaxreceipts')) . "');"),
+        'submitOnce' => TRUE,
       ),
     );
     $this->addButtons($buttons);

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -86,7 +86,7 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
         'type' => 'next',
         'name' => 'Issue Tax Receipts',
         'isDefault' => TRUE,
-        'js' => array('onclick' => "return submitOnce(this,'{$this->_name}','" . ts('Processing', array('domain' => 'org.civicrm.cdntaxreceipts')) . "');"),
+        'submitOnce' => TRUE,
       ),
     );
     $this->addButtons($buttons);

--- a/info.xml
+++ b/info.xml
@@ -16,7 +16,7 @@
   <version>1.5.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.7</ver>
+    <ver>5.12</ver>
   </compatibility>
   <urls>
     <url desc="documentation">https://github.com/jake-mw/CDNTaxReceipts/blob/master/README.md</url>


### PR DESCRIPTION
This new method of adding submitOnce behavior to form buttons has been available since 5.12 (hence the version bump in `info.xml`). The old method of injecting raw javascript is deprecated and the old submitOnce function referenced here will eventually be removed from core.