### PR TITLE
Replace deprecated CRM_Core_BAO_Settings functions

### DIFF
--- a/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
+++ b/CRM/Cdntaxreceipts/Form/Report/ReceiptsNotIssued.php
@@ -89,10 +89,10 @@ class CRM_Cdntaxreceipts_Form_Report_ReceiptsNotIssued extends CRM_Report_Form {
       ),
     );
 
-    if (CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'enable_advanced_eligibility_report', NULL, 0) == 1) {
+    if (Civi::settings()->get('enable_advanced_eligibility_report') == 1) {
       $enable_options = array( 1 => ts('Yes'), 0 => ts('No'));
     }
-    elseif (CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'enable_advanced_eligibility_report', NULL, 0) == 0) {
+    elseif (Civi::settings()->get('enable_advanced_eligibility_report') == 0) {
       $enable_options = array( 0 => ts('No'), 1 => ts('Yes'));
     }
     $this->_options =

--- a/CRM/Cdntaxreceipts/Form/Settings.php
+++ b/CRM/Cdntaxreceipts/Form/Settings.php
@@ -70,31 +70,31 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     }
     else if ( $mode == 'defaults' ) {
       $defaults = array(
-        'org_name' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_name'),
-        'org_address_line1' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_address_line1'),
-        'org_address_line2' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_address_line2'),
-        'org_tel' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_tel'),
-        'org_fax' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_fax'),
-        'org_email' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_email'),
-        'org_web' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_web'),
-        'receipt_logo' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_logo'),
-        'receipt_signature' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_signature'),
-        'receipt_watermark' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_watermark'),
-        'receipt_pdftemplate' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_pdftemplate'),
-        'org_charitable_no' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'org_charitable_no'),
+        'org_name' => Civi::settings()->get('org_name'),
+        'org_address_line1' => Civi::settings()->get('org_address_line1'),
+        'org_address_line2' => Civi::settings()->get('org_address_line2'),
+        'org_tel' => Civi::settings()->get('org_tel'),
+        'org_fax' => Civi::settings()->get('org_fax'),
+        'org_email' => Civi::settings()->get('org_email'),
+        'org_web' => Civi::settings()->get('org_web'),
+        'receipt_logo' => Civi::settings()->get('receipt_logo'),
+        'receipt_signature' => Civi::settings()->get('receipt_signature'),
+        'receipt_watermark' => Civi::settings()->get('receipt_watermark'),
+        'receipt_pdftemplate' => Civi::settings()->get('receipt_pdftemplate'),
+        'org_charitable_no' => Civi::settings()->get('org_charitable_no'),
       );
       return $defaults;
     }
     else if ( $mode == 'post' ) {
       $values = $this->exportValues();
-      CRM_Core_BAO_Setting::setItem($values['org_name'], self::SETTINGS, 'org_name');
-      CRM_Core_BAO_Setting::setItem($values['org_address_line1'], self::SETTINGS, 'org_address_line1');
-      CRM_Core_BAO_Setting::setItem($values['org_address_line2'], self::SETTINGS, 'org_address_line2');
-      CRM_Core_BAO_Setting::setItem($values['org_tel'], self::SETTINGS, 'org_tel');
-      CRM_Core_BAO_Setting::setItem($values['org_fax'], self::SETTINGS, 'org_fax');
-      CRM_Core_BAO_Setting::setItem($values['org_email'], self::SETTINGS, 'org_email');
-      CRM_Core_BAO_Setting::setItem($values['org_web'], self::SETTINGS, 'org_web');
-      CRM_Core_BAO_Setting::setItem($values['org_charitable_no'], self::SETTINGS, 'org_charitable_no');
+      Civi::settings()->set('org_name', $values['org_name']);
+      Civi::settings()->set('org_address_line1', $values['org_address_line1']);
+      Civi::settings()->set('org_address_line2', $values['org_address_line2']);
+      Civi::settings()->set('org_tel', $values['org_tel']);
+      Civi::settings()->set('org_fax', $values['org_fax']);
+      Civi::settings()->set('org_email', $values['org_email']);
+      Civi::settings()->set('org_web', $values['org_web']);
+      Civi::settings()->set('org_charitable_no', $values['org_charitable_no']);
     }
 
   }
@@ -132,18 +132,17 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     }
     else if ( $mode == 'defaults' ) {
       $defaults = array(
-        'receipt_prefix' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_prefix'),
-        'receipt_serial' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_serial'),
-        'receipt_authorized_signature_text' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'receipt_authorized_signature_text'),
+        'receipt_prefix' => Civi::settings()->get('receipt_prefix'),
+        'receipt_serial' => Civi::settings()->get('receipt_serial'),
+        'receipt_authorized_signature_text' => Civi::settings()->get('receipt_authorized_signature_text'),
       );
       return $defaults;
     }
     else if ( $mode == 'post' ) {
       $values = $this->exportValues();
-      CRM_Core_BAO_Setting::setItem($values['receipt_prefix'], self::SETTINGS, 'receipt_prefix');
-      CRM_Core_BAO_Setting::setItem($values['receipt_serial'] ?? 0, self::SETTINGS, 'receipt_serial');
-      CRM_Core_BAO_Setting::setItem($values['receipt_authorized_signature_text'], self::SETTINGS, 'receipt_authorized_signature_text');
-
+      Civi::settings()->set('receipt_prefix', $values['receipt_prefix']);
+      Civi::settings()->set('receipt_serial', $values['receipt_serial'] ?? 0);
+      Civi::settings()->set('receipt_authorized_signature_text', $values['receipt_authorized_signature_text']);
       $receipt_logo = $this->getSubmitValue('receipt_logo');
       $receipt_signature = $this->getSubmitValue('receipt_signature');
       $receipt_watermark = $this->getSubmitValue('receipt_watermark');
@@ -158,7 +157,7 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
             if (!move_uploaded_file($upload_file['tmp_name'], $filename)) {
               CRM_Core_Error::fatal(ts('Could not upload the file'));
             }
-            CRM_Core_BAO_Setting::setItem($filename, self::SETTINGS, $key);
+            Civi::settings()->set($key, $filename);
           }
         }
       }
@@ -190,18 +189,17 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     else if ( $mode == 'defaults' ) {
       $defaults = array(
         'issue_inkind' => 0,
-        'delivery_method' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY),
-        'attach_to_workflows' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'attach_to_workflows', NULL, 0),
-        'enable_advanced_eligibility_report' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'enable_advanced_eligibility_report', NULL, 0),
+        'delivery_method' => Civi::settings()->get('delivery_method') ?? CDNTAX_DELIVERY_PRINT_ONLY,
+        'attach_to_workflows' => Civi::settings()->get('attach_to_workflows') ?? 0,
+        'enable_advanced_eligibility_report' => Civi::settings()->get('enable_advanced_eligibility_report') ?? 0,
       );
       return $defaults;
     }
     else if ( $mode == 'post' ) {
       $values = $this->exportValues();
-      CRM_Core_BAO_Setting::setItem($values['delivery_method'], self::SETTINGS, 'delivery_method');
-      CRM_Core_BAO_Setting::setItem($values['attach_to_workflows'], self::SETTINGS, 'attach_to_workflows');
-      CRM_Core_BAO_Setting::setItem($values['enable_advanced_eligibility_report'], self::SETTINGS, 'enable_advanced_eligibility_report');
-
+      Civi::settings()->set('delivery_method', $values['delivery_method']);
+      Civi::settings()->set('attach_to_workflows', $values['attach_to_workflows']);
+      Civi::settings()->set('enable_advanced_eligibility_report', $values['enable_advanced_eligibility_report']);
       if (isset($values['issue_inkind']) == TRUE) {
         if ( $values['issue_inkind'] == 1 ) {
           cdntaxreceipts_configure_inkind_fields();
@@ -220,15 +218,15 @@ class CRM_Cdntaxreceipts_Form_Settings extends CRM_Core_Form {
     }
     else if ( $mode == 'defaults' ) {
       $defaults = array(
-        'email_from' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'email_from'),
-        'email_archive' => CRM_Core_BAO_Setting::getItem(self::SETTINGS, 'email_archive'),
+        'email_from' => Civi::settings()->get('email_from'),
+        'email_archive' => Civi::settings()->get('email_archive'),
       );
       return $defaults;
     }
     else if ( $mode == 'post' ) {
       $values = $this->exportValues();
-      CRM_Core_BAO_Setting::setItem($values['email_from'], self::SETTINGS, 'email_from');
-      CRM_Core_BAO_Setting::setItem($values['email_archive'], self::SETTINGS, 'email_archive');
+      Civi::settings()->set('email_from', $values['email_from']);
+      Civi::settings()->set('email_archive', $values['email_archive']);
     }
   }
 

--- a/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAggregateTaxReceipts.php
@@ -132,7 +132,7 @@ class CRM_Cdntaxreceipts_Task_IssueAggregateTaxReceipts extends CRM_Contribute_F
     $this->assign('receiptList', $this->_receipts);
     $this->assign('receiptYears', $this->_years);
 
-    $delivery_method = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY);
+    $delivery_method = Civi::settings()->get('delivery_method') ?? CDNTAX_DELIVERY_PRINT_ONLY;
     $this->assign('deliveryMethod', $delivery_method);
 
     // add radio buttons

--- a/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueAnnualTaxReceipts.php
@@ -77,7 +77,7 @@ class CRM_Cdntaxreceipts_Task_IssueAnnualTaxReceipts extends CRM_Contact_Form_Ta
     $this->assign('receiptTotal', $receiptTotal);
     $this->assign('receiptYears', $this->_years);
 
-    $delivery_method = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY);
+    $delivery_method = Civi::settings()->get('delivery_method') ?? CDNTAX_DELIVERY_PRINT_ONLY;
     $this->assign('deliveryMethod', $delivery_method);
 
     // add radio buttons

--- a/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
+++ b/CRM/Cdntaxreceipts/Task/IssueSingleTaxReceipts.php
@@ -65,7 +65,7 @@ class CRM_Cdntaxreceipts_Task_IssueSingleTaxReceipts extends CRM_Contribute_Form
     $this->assign('duplicateTotal', $duplicateTotal);
     $this->assign('receiptTotal', $receiptTotal);
 
-    $delivery_method = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY);
+    $delivery_method = Civi::settings()->get('delivery_method') ?? CDNTAX_DELIVERY_PRINT_ONLY;
     $this->assign('deliveryMethod', $delivery_method);
 
     // add radio buttons

--- a/CRM/Cdntaxreceipts/Upgrader.php
+++ b/CRM/Cdntaxreceipts/Upgrader.php
@@ -72,19 +72,19 @@ AND COLUMN_NAME = 'receipt_status'");
 
   public function upgrade_1322() {
     $this->ctx->log->info('Applying update 1322: Message Templates');
-    $current_message = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'email_message');
-    $current_subject = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'email_subject') . ' {$receipt.receipt_no}';
+    $current_message = Civi::settings()->get('email_message');
+    $current_subject = Civi::settings()->get('email_subject') . ' {$receipt.receipt_no}';
     return $this->_create_message_template($current_message, $current_subject);
   }
 
   public function upgrade_1410() {
     $this->ctx->log->info('Applying update 1410: Data mode');
-    $email_enabled = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'enable_email');
+    $email_enabled = Civi::settings()->get('enable_email');
     if ($email_enabled) {
-      CRM_Core_BAO_Setting::setItem(1, CDNTAX_SETTINGS, 'delivery_method');
+      Civi::settings()->set('delivery_method', 1);
     }
     else {
-      CRM_Core_BAO_Setting::setItem(0, CDNTAX_SETTINGS, 'delivery_method');
+      Civi::settings()->set('delivery_method', 0);
     }
     return TRUE;
   }

--- a/CRM/Cdntaxreceipts/Upgrader/Base.php
+++ b/CRM/Cdntaxreceipts/Upgrader/Base.php
@@ -221,7 +221,7 @@ class CRM_Cdntaxreceipts_Upgrader_Base {
   public function getCurrentRevision() {
     // return CRM_Core_BAO_Extension::getSchemaVersion($this->extensionName);
     $key = $this->extensionName . ':version';
-    return CRM_Core_BAO_Setting::getItem('Extension', $key);
+    return Civi::settings()->get($key);
   }
 
   public function setCurrentRevision($revision) {
@@ -231,7 +231,9 @@ class CRM_Cdntaxreceipts_Upgrader_Base {
     // CRM_Core_BAO_Extension::setSchemaVersion($this->extensionName, $revision);
 
     $key = $this->extensionName . ':version';
-    CRM_Core_BAO_Setting::setItem($revision, 'Extension', $key);
+    // Longer-term this file should be brought in line with newer versions of
+    // civix but this should still work for now.
+    Civi::settings()->set($key, $revision);
     return TRUE;
   }
 

--- a/cdntaxreceipts.functions.inc
+++ b/cdntaxreceipts.functions.inc
@@ -13,11 +13,11 @@ require_once('FPDI/fpdi.php');
      * include a background template for every page
      */
     function Header() {
-      $pdf_template_file = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_pdftemplate');
+      $pdf_template_file = Civi::settings()->get('receipt_pdftemplate');
       if (!empty($pdf_template_file)) {
 
         if (is_null($this->_tplIdx)) {
-          $pdf_template_file = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_pdftemplate');
+          $pdf_template_file = Civi::settings()->get('receipt_pdftemplate');
           $this->setSourceFile($pdf_template_file);
           $this->_tplIdx = $this->importPage(1);
         }
@@ -58,7 +58,7 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
   $preferred_language = CRM_Core_DAO::getFieldValue('CRM_Contact_DAO_Contact', $receipt['contact_id'], 'preferred_language');
   _cdntaxreceipts_setReceiptanguage($preferred_language);
 
-  $serial_receipt = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_serial');
+  $serial_receipt = Civi::settings()->get('receipt_serial');
   if ($serial_receipt && empty($receipt['is_duplicate'])) {
     // use my experimental alternative to generating serial receipt numbers, unless this is a re-issue
     $lock = new CRM_Core_Lock('cdntaxreceipts.processTaxReceipt');
@@ -68,7 +68,7 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
       return array(FALSE,'',NULL);
     }
     $next_id = cdntaxreceipts_log_next_id();
-    $receipt['receipt_no'] = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($next_id, 8, 0, STR_PAD_LEFT);
+    $receipt['receipt_no'] = Civi::settings()->get('receipt_prefix') . str_pad($next_id, 8, 0, STR_PAD_LEFT);
   }
   // allow modules to alter any details
   // invoke hook_cdntaxreceipts_alter_receipt(&$receipt)
@@ -92,9 +92,9 @@ function cdntaxreceipts_processTaxReceipt($receipt, &$collectedPdf = NULL, $mode
     }
     else {
       // generate an email to the tax archive and possibly to the donor
-      $org_name = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_name');
-      $email_from = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'email_from');
-      $email_archive = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'email_archive');
+      $org_name = Civi::settings()->get('org_name');
+      $email_from = Civi::settings()->get('email_from');
+      $email_archive = Civi::settings()->get('email_archive');
 
       // get all the basic contact information
       $params = array(
@@ -243,7 +243,7 @@ function cdntaxreceipts_generateFormattedReceipt($receipt, &$collectedPdf = NULL
   $pdf = new PDF(PDF_PAGE_ORIENTATION, PDF_UNIT, 'LETTER', TRUE, 'UTF-8', FALSE);
   $pdf->Open();
 
-  $pdf->SetAuthor(CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_name'));
+  $pdf->SetAuthor(Civi::settings()->get('org_name'));
 
   $mymargin_left = 12;
   $mymargin_top = 6;
@@ -373,36 +373,40 @@ function _cdntaxreceipts_writeReceipt(&$pdf, $pdf_variables) {
     $pdf->Image($pdf_img_files_path . 'duplicate_trans.png', $mymargin_left + 65, $mymargin_top, '', 45);
   }
   // Top left section
-  $pdf_template_file = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_pdftemplate');
+  $pdf_template_file = Civi::settings()->get('receipt_pdftemplate');
   if (!empty($pdf_template_file)) {
   }
   else {
-    $pdf->Image(CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_logo', NULL, $pdf_img_files_path . 'your-logo.png'), $mymargin_left, $mymargin_top, '', 30);
+    $receipt_logo = Civi::settings()->get('receipt_logo');
+    if ( empty($receipt_logo) ) {
+      $receipt_logo = $pdf_img_files_path . 'your-logo.png';
+    }
+    $pdf->Image($receipt_logo, $mymargin_left, $mymargin_top, '', 30);
 
   // Top right section
   $pdf->SetFont('Helvetica', '', 8);
   $pdf->SetY($mymargin_top);
-  $pdf->Write(10, CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_name'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
+  $pdf->Write(10, Civi::settings()->get('org_name'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
   $pdf->SetY($mymargin_top + 4);
-  $pdf->Write(10, CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_address_line1'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
+  $pdf->Write(10, Civi::settings()->get('org_address_line1'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
   $pdf->SetY($mymargin_top + 8);
-  $pdf->Write(10, CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_address_line2'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
+  $pdf->Write(10, Civi::settings()->get('org_address_line2'), '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
   $pdf->SetY($mymargin_top + 12);
 
-  $telTxt = ts('Tel: %1', array(1 => CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_tel'), 'domain' => 'org.civicrm.cdntaxreceipts'));
-  if ( CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_fax' ) != '' ) {
-    $telTxt .= '; ' . ts('Fax: %1', array(1 => CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_fax'), 'domain' => 'org.civicrm.cdntaxreceipts'));
+  $telTxt = ts('Tel: %1', array(1 => Civi::settings()->get('org_tel'), 'domain' => 'org.civicrm.cdntaxreceipts'));
+  if ( Civi::settings()->get('org_fax' ) != '' ) {
+    $telTxt .= '; ' . ts('Fax: %1', array(1 => Civi::settings()->get('org_fax'), 'domain' => 'org.civicrm.cdntaxreceipts'));
   }
   $pdf->Write(10, $telTxt, '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
   $pdf->SetFont('Helvetica', 'I', 8);
   $pdf->SetY($mymargin_top + 16);
 
   $emailTxt = ts('Email: %1; Website: %2', array(
-    1 => CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_email'),
-    2 => CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_web'),
+    1 => Civi::settings()->get('org_email'),
+    2 => Civi::settings()->get('org_web'),
     'domain' => 'org.civicrm.cdntaxreceipts')
   );
-  $registrationTxt = ts('Charitable Registration: %1', array(1 => CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_charitable_no'), 'domain' => 'org.civicrm.cdntaxreceipts'));
+  $registrationTxt = ts('Charitable Registration: %1', array(1 => Civi::settings()->get('org_charitable_no'), 'domain' => 'org.civicrm.cdntaxreceipts'));
 
   $pdf->Write(10, $emailTxt, '', 0, 'R', TRUE, 0, FALSE, FALSE, 0);
   $pdf->SetY($mymargin_top + 20);
@@ -412,12 +416,12 @@ function _cdntaxreceipts_writeReceipt(&$pdf, $pdf_variables) {
   // Right section
   $x_detailscolumn = 120;
   $y_detailscolumnstart = 22;
-  $pdf_template_file = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_pdftemplate');
+  $pdf_template_file = Civi::settings()->get('receipt_pdftemplate');
   if (!empty($pdf_template_file)) {
   }
   else {
-    $background_image = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_watermark');
-    if ( $background_image ) $pdf->Image(CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_watermark'), $mymargin_left + $x_detailscolumn, $mymargin_top + $y_detailscolumnstart + 6, '', 40);
+    $background_image = Civi::settings()->get('receipt_watermark');
+    if ( $background_image ) $pdf->Image(Civi::settings()->get('receipt_watermark'), $mymargin_left + $x_detailscolumn, $mymargin_top + $y_detailscolumnstart + 6, '', 40);
   }
   $pdf->SetXY($mymargin_left + $x_detailscolumn, $mymargin_top + $y_detailscolumnstart + 6);
   $pdf->SetFont('Helvetica', 'B', 8);
@@ -534,14 +538,14 @@ function _cdntaxreceipts_writeReceipt(&$pdf, $pdf_variables) {
     $pdf->Write(10, ts('Thank you!', array('domain' => 'org.civicrm.cdntaxreceipts')));
 
     // Bottom right section
-    $signature = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_authorized_signature_text');
+    $signature = Civi::settings()->get('receipt_authorized_signature_text');
     if ( $signature == '' ) {
       $signature = ts('Authorized Signature', array('domain' => 'org.civicrm.cdntaxreceipts'));
     }
     $sig_offset = strlen($signature) - 20;
-    $pdf_template_file = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_pdftemplate');
+    $pdf_template_file = Civi::settings()->get('receipt_pdftemplate');
 
-    $sig_image = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_signature');
+    $sig_image = Civi::settings()->get('receipt_signature');
     if (empty($sig_image)) {
       $sig_image = $pdf_img_files_path . 'authorized-signature.png';
     }
@@ -684,7 +688,7 @@ function cdntaxreceipts_issueTaxReceipt($contribution, &$collectedPdf = NULL, $m
     $receipt_no = $receipt['receipt_no'];
   }
   else { // generate a receipt number
-    $receipt_no = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($contribution->id, 8, 0, STR_PAD_LEFT);
+    $receipt_no = Civi::settings()->get('receipt_prefix') . str_pad($contribution->id, 8, 0, STR_PAD_LEFT);
   }
 
   // determine the send method
@@ -954,7 +958,7 @@ function cdntaxreceipts_issueAnnualTaxReceipt( $contactId, $year, &$collectedPdf
     }
 
     // generate a receipt number
-    $receiptNo = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($receiptContributions[0]['contribution_id'], 8, 0, STR_PAD_LEFT);
+    $receiptNo = Civi::settings()->get('receipt_prefix') . str_pad($receiptContributions[0]['contribution_id'], 8, 0, STR_PAD_LEFT);
 
     $receipt = array(
       'receipt_no' => $receiptNo,
@@ -1054,7 +1058,7 @@ function cdntaxreceipts_issueAggregateTaxReceipt($contactId, $year, $contributio
     }
 
     // generate a receipt number
-    $receiptNo = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'receipt_prefix') . str_pad($receiptContributions[0]['contribution_id'], 8, 0, STR_PAD_LEFT);
+    $receiptNo = Civi::settings()->get('receipt_prefix') . str_pad($receiptContributions[0]['contribution_id'], 8, 0, STR_PAD_LEFT);
 
     $receipt = array(
       'receipt_no' => $receiptNo,
@@ -1080,7 +1084,7 @@ function cdntaxreceipts_issueAggregateTaxReceipt($contactId, $year, $contributio
  */
 function cdntaxreceipts_sendMethodForContact( $contactId ) {
 
-  $delivery_method = CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY);
+  $delivery_method = Civi::settings()->get('delivery_method', NULL, CDNTAX_DELIVERY_PRINT_ONLY);
   if ($delivery_method == CDNTAX_DELIVERY_DATA_ONLY) {
     return array('data', NULL);
   }
@@ -1142,7 +1146,7 @@ function cdntaxreceipts_openCollectedPDF() {
     $pdf = new PDF(PDF_PAGE_ORIENTATION, PDF_UNIT, 'LETTER', TRUE, 'UTF-8', FALSE);
     $pdf->Open();
 
-    $pdf->SetAuthor(CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'org_name'));
+    $pdf->SetAuthor(Civi::settings()->get('org_name'));
 
     $mymargin_left = 12;
     $mymargin_top = 6;

--- a/cdntaxreceipts.php
+++ b/cdntaxreceipts.php
@@ -312,7 +312,7 @@ function cdntaxreceipts_civicrm_alterMailParams(&$params, $context) {
     }
 
     // is the extension configured to send receipts attached to automated workflows?
-    if (!CRM_Core_BAO_Setting::getItem(CDNTAX_SETTINGS, 'attach_to_workflows', NULL, FALSE)) {
+    if (!Civi::settings()->get('attach_to_workflows')) {
       return;
     }
 


### PR DESCRIPTION
Alternate PR to address issue https://github.com/jake-mw/CDNTaxReceipts/issues/74

There's a pending separate fix from @KarinG for `receipt_serial` so I'll rebase this after.

This is basically the same as PR #97 but with most of the comments there applied. It's more or less what I was testing with while testing 97, and I did another round of testing here.

I also faked an upgrade to test out the one that was marked "unsure" and it updates the right db field and everything seemed ok. Longer term the base upgrader file should be updated to match newer civix's.

Also two of the lines being updated had **tabs** (!!) instead of spaces so fixed that while at it. TABS!!!!